### PR TITLE
Update logo link

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -12,7 +12,7 @@
 
 <header>
 	<div>
-		<h1 style="margin:0"><img id="logo" src="/wrapper/pages/img/list_logo.png" alt="Wrapper: Offline for schools remastered"/></h1>
+		<h1 style="margin:0"><img id="logo" src="https://josephcrosmanplays532.github.io/0655491F-3FB5-440B-A419-B5CDD56C055C.png" alt="Wrapper: Offline for schools remastered"/></h1>
 	</div>
 </header>
 


### PR DESCRIPTION
According to what I found out, localhost:4664 does not take you to /wrapper/pages/img/list_logo.png. So I recommend that the index.html file has this link https://josephcrosmanplays532.github.io/0655491F-3FB5-440B-A419-B5CDD56C055C.png so the WO4SR logo displays properly.